### PR TITLE
fix(bootstrap): Update bootstrap to 4.6.2 to fix warning with autoprefixer

### DIFF
--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -20,7 +20,7 @@
         "@typescript-eslint/eslint-plugin": "^5.40.1",
         "@typescript-eslint/parser": "^5.40.1",
         "@vitest/coverage-c8": "^0.29.2",
-        "bootstrap": "4.6.1",
+        "bootstrap": "^4.6.2",
         "copyfiles": "2.4.1",
         "cross-env": "^7.0.3",
         "eslint": "^8.26.0",
@@ -5873,14 +5873,20 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
       "peerDependencies": {
         "jquery": "1.9.1 - 3",
         "popper.js": "^1.16.1"
@@ -22698,9 +22704,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
       "dev": true,
       "requires": {}
     },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -60,7 +60,7 @@
     "@typescript-eslint/eslint-plugin": "^5.40.1",
     "@typescript-eslint/parser": "^5.40.1",
     "@vitest/coverage-c8": "^0.29.2",
-    "bootstrap": "4.6.1",
+    "bootstrap": "^4.6.2",
     "copyfiles": "2.4.1",
     "cross-env": "^7.0.3",
     "eslint": "^8.26.0",


### PR DESCRIPTION
Bootstrap 4.6.1 causes a warning on build for `packages\react `

```
Warning
(6:62003) autoprefixer: Replace color-adjust to print-color-adjust. 
The color-adjust shorthand is currently deprecated.
```

This causes a CI Build of `packages\react` to fail if warnings are set to fail.
Upgrading to Bootstrap 4.6.2, updates the autoprefixer lib with a fix.

ref: https://stackoverflow.com/questions/72511039/autoprefixer-replace-color-adjust-to-print-color-adjust-the-color-adjust-short
and
https://github.com/twbs/bootstrap/releases/tag/v4.6.2

