### PR TITLE
refactor(build): Don't run azure deploys or publish on PR's

### DIFF
--- a/.github/workflows/azure-static-web-apps-black-rock-0dc6b0d03.yml
+++ b/.github/workflows/azure-static-web-apps-black-rock-0dc6b0d03.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - master
 
 jobs:
   skip_ci:

--- a/.github/workflows/azure-static-web-apps-icy-glacier-004ab4303.yml
+++ b/.github/workflows/azure-static-web-apps-icy-glacier-004ab4303.yml
@@ -4,14 +4,17 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - master
 
 jobs:
+  skip_ci:
+    runs-on: ubuntu-latest
+    outputs:
+      canSkip: ${{ steps.check.outputs.canSkip }}
+    steps:
+      - id: check
+        uses: Legorooj/skip-ci@main
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')) && !github.event.pull_request.head.repo.fork && needs.skip_ci.outputs.canSkip != 'true'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,8 +6,6 @@ name: React Oidc CI
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   skip_ci:
@@ -20,7 +18,7 @@ jobs:
   build:
     environment: react-oidc
     runs-on: ubuntu-latest
-    if: ${{ needs.skip_ci.outputs.canSkip != 'true' }}
+    if: needs.skip_ci.outputs.canSkip != 'true'
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Issue
When a PR is raised, the pipeline workflows attempt to run the Build/Publish and the Azure publish jobs.
These appear to fail often (always?).

## Change
Removed trigger on pull_requests for Azure and Publish workflows.
Leaving only trigger on push->master

## Additional note
Action `egorooj/skip-ci@main` may not be required anymore, see (https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs)