### PR TITLE
fix(modules): Fix issue with compilation of react package to ESmodules format

### DIFF
--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "dist",
     "baseUrl": "./",
     "jsx": "react-jsx",
-    "module": "CommonJS",
+    "module": "ESNext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## Bugfix
- Error issue introduced in e128be41573e158cc052e6ae1f08805adbcca058 when changed package.json to module but typescript still emit commonJS format.

This change sets typescript module type is ESModules so it emits to match package.json `"type":"module"`

## A picture tells a thousand words
![chrome_UwdeRL5kX9](https://user-images.githubusercontent.com/127927/226160466-65150f13-792e-47a8-981b-2bc1303a1d16.jpg)

## Before this PR

React package will throw error `exports is not defined. in fetchtoken

## After this PR

Described error should be resolved.
