### PR TITLE
fix(react): Fix issue where imports not found due to missing .js extension

### DIFF
--- a/packages/react/src/App.tsx
+++ b/packages/react/src/App.tsx
@@ -1,12 +1,12 @@
 import React, { useReducer } from 'react';
 import { BrowserRouter, NavLink, Route, Routes } from 'react-router-dom';
 
-import { configurationIdentityServer } from './configurations';
-import { FetchUserHoc, FetchUserHook } from './FetchUser';
-import { Home } from './Home';
-import { MultiAuthContainer } from './MultiAuth';
+import { configurationIdentityServer } from './configurations.js';
+import { FetchUserHoc, FetchUserHook } from './FetchUser.js';
+import { Home } from './Home.js';
+import { MultiAuthContainer } from './MultiAuth.js';
 import { OidcProvider, withOidcSecure } from './oidc';
-import { Profile, SecureProfile } from './Profile';
+import { Profile, SecureProfile } from './Profile.js';
 
 const OidcSecureHoc = withOidcSecure(Profile);
 

--- a/packages/react/src/oidc/FetchToken.tsx
+++ b/packages/react/src/oidc/FetchToken.tsx
@@ -1,4 +1,4 @@
-import { VanillaOidc } from './vanilla/vanillaOidc';
+import { VanillaOidc } from './vanilla/vanillaOidc.js';
 
 export type Fetch = typeof window.fetch;
 

--- a/packages/react/src/oidc/OidcProvider.tsx
+++ b/packages/react/src/oidc/OidcProvider.tsx
@@ -1,12 +1,12 @@
 import { ComponentType, FC, PropsWithChildren, useEffect, useState } from 'react';
 
-import AuthenticatingError from './core/default-component/AuthenticateError.component';
-import { Authenticating, CallBackSuccess, Loading, SessionLost } from './core/default-component/index';
-import ServiceWorkerNotSupported from './core/default-component/ServiceWorkerNotSupported.component';
-import OidcRoutes from './core/routes/OidcRoutes';
-import { CustomHistory } from './core/routes/withRouter';
-import { OidcConfiguration } from './vanilla/types';
-import { VanillaOidc } from './vanilla/vanillaOidc';
+import AuthenticatingError from './core/default-component/AuthenticateError.component.js';
+import { Authenticating, CallBackSuccess, Loading, SessionLost } from './core/default-component/index.js';
+import ServiceWorkerNotSupported from './core/default-component/ServiceWorkerNotSupported.component.js';
+import OidcRoutes from './core/routes/OidcRoutes.js';
+import { CustomHistory } from './core/routes/withRouter.js';
+import { OidcConfiguration } from './vanilla/types.js';
+import { VanillaOidc } from './vanilla/vanillaOidc.js';
 
 export type oidcContext = {
     (name?: string): VanillaOidc;

--- a/packages/react/src/oidc/OidcSecure.tsx
+++ b/packages/react/src/oidc/OidcSecure.tsx
@@ -1,7 +1,7 @@
 import { FC, PropsWithChildren, useEffect } from 'react';
 
-import { StringMap } from './vanilla/types';
-import { VanillaOidc } from './vanilla/vanillaOidc';
+import { StringMap } from './vanilla/types.js';
+import { VanillaOidc } from './vanilla/vanillaOidc.js';
 
 export type OidcSecureProps = {
     callbackPath?:string;

--- a/packages/react/src/oidc/ReactOidc.tsx
+++ b/packages/react/src/oidc/ReactOidc.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import { StringMap } from './vanilla/types';
-import { VanillaOidc } from './vanilla/vanillaOidc';
+import { StringMap } from './vanilla/types.js';
+import { VanillaOidc } from './vanilla/vanillaOidc.js';
 
 const defaultConfigurationName = 'default';
 

--- a/packages/react/src/oidc/User.ts
+++ b/packages/react/src/oidc/User.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { OidcUserInfo, VanillaOidc } from './vanilla/vanillaOidc';
+import { OidcUserInfo, VanillaOidc } from './vanilla/vanillaOidc.js';
 
 export enum OidcUserStatus {
     Unauthenticated= 'Unauthenticated',

--- a/packages/react/src/oidc/core/default-component/Callback.component.tsx
+++ b/packages/react/src/oidc/core/default-component/Callback.component.tsx
@@ -1,8 +1,8 @@
 import React, { ComponentType, useEffect, useState } from 'react';
 
-import { VanillaOidc } from '../../vanilla/vanillaOidc';
-import { getCustomHistory } from '../routes/withRouter';
-import AuthenticatingError from './AuthenticateError.component';
+import { VanillaOidc } from '../../vanilla/vanillaOidc.js';
+import { getCustomHistory } from '../routes/withRouter.js';
+import AuthenticatingError from './AuthenticateError.component.js';
 
 export const CallBackSuccess: ComponentType<any> = () => (<div className="oidc-callback">
   <div className="oidc-callback__container">

--- a/packages/react/src/oidc/core/default-component/SilentCallback.component.tsx
+++ b/packages/react/src/oidc/core/default-component/SilentCallback.component.tsx
@@ -1,6 +1,6 @@
 import { ComponentType, useEffect } from 'react';
 
-import { VanillaOidc } from '../../vanilla/vanillaOidc';
+import { VanillaOidc } from '../../vanilla/vanillaOidc.js';
 
 const SilentCallbackManager: ComponentType<any> = ({ configurationName }) => {
     useEffect(() => {

--- a/packages/react/src/oidc/core/default-component/SilentLogin.component.tsx
+++ b/packages/react/src/oidc/core/default-component/SilentLogin.component.tsx
@@ -1,7 +1,7 @@
 import { ComponentType, useEffect } from 'react';
 
-import { getParseQueryStringFromLocation } from '../../vanilla/route-utils';
-import { VanillaOidc } from '../../vanilla/vanillaOidc';
+import { getParseQueryStringFromLocation } from '../../vanilla/route-utils.js';
+import { VanillaOidc } from '../../vanilla/vanillaOidc.js';
 
 const SilentLogin: ComponentType<any> = ({ configurationName }) => {
     const queryParams = getParseQueryStringFromLocation(window.location.href);

--- a/packages/react/src/oidc/core/default-component/index.ts
+++ b/packages/react/src/oidc/core/default-component/index.ts
@@ -1,6 +1,6 @@
-export { default as AuthenticateError } from './AuthenticateError.component';
-export { default as Authenticating } from './Authenticating.component';
-export { default as Callback, CallBackSuccess } from './Callback.component';
-export { default as Loading } from './Loading.component';
-export { default as ServiceWorkerNotSupported } from './ServiceWorkerNotSupported.component';
-export { default as SessionLost } from './SessionLost.component';
+export { default as AuthenticateError } from './AuthenticateError.component.js';
+export { default as Authenticating } from './Authenticating.component.js';
+export { default as Callback, CallBackSuccess } from './Callback.component.js';
+export { default as Loading } from './Loading.component.js';
+export { default as ServiceWorkerNotSupported } from './ServiceWorkerNotSupported.component.js';
+export { default as SessionLost } from './SessionLost.component.js';

--- a/packages/react/src/oidc/core/routes/OidcRoutes.tsx
+++ b/packages/react/src/oidc/core/routes/OidcRoutes.tsx
@@ -1,10 +1,10 @@
 import React, { ComponentType, FC, PropsWithChildren, useEffect, useState } from 'react';
 
-import { getPath } from '../../vanilla/route-utils';
-import CallbackComponent from '../default-component/Callback.component';
-import SilentCallbackComponent from '../default-component/SilentCallback.component';
-import SilentLoginComponent from '../default-component/SilentLogin.component';
-import { CustomHistory } from './withRouter';
+import { getPath } from '../../vanilla/route-utils.js';
+import CallbackComponent from '../default-component/Callback.component.js';
+import SilentCallbackComponent from '../default-component/SilentCallback.component.js';
+import SilentLoginComponent from '../default-component/SilentLogin.component.js';
+import { CustomHistory } from './withRouter.js';
 
 const defaultProps: Partial<OidcRoutesProps> = {
 

--- a/packages/react/src/oidc/index.ts
+++ b/packages/react/src/oidc/index.ts
@@ -1,7 +1,7 @@
-export { useOidcFetch, withOidcFetch } from './FetchToken';
-export { OidcProvider } from './OidcProvider';
-export { OidcSecure, withOidcSecure } from './OidcSecure';
-export { useOidc, useOidcAccessToken, useOidcIdToken } from './ReactOidc';
-export { OidcUserStatus, useOidcUser } from './User';
-export { TokenRenewMode } from './vanilla/parseTokens';
-export type { AuthorityConfiguration, OidcConfiguration, StringMap } from './vanilla/types';
+export { useOidcFetch, withOidcFetch } from './FetchToken.js';
+export { OidcProvider } from './OidcProvider.js';
+export { OidcSecure, withOidcSecure } from './OidcSecure.js';
+export { useOidc, useOidcAccessToken, useOidcIdToken } from './ReactOidc.js';
+export { OidcUserStatus, useOidcUser } from './User.js';
+export { TokenRenewMode } from './vanilla/parseTokens.js';
+export type { AuthorityConfiguration, OidcConfiguration, StringMap } from './vanilla/types.js';

--- a/packages/react/src/oidc/vanilla/checkSession.ts
+++ b/packages/react/src/oidc/vanilla/checkSession.ts
@@ -1,6 +1,6 @@
-import { CheckSessionIFrame } from './checkSessionIFrame';
-import { _silentLoginAsync, SilentLoginResponse } from './silentLogin';
-import { OidcConfiguration } from './types';
+import { CheckSessionIFrame } from './checkSessionIFrame.js';
+import { _silentLoginAsync, SilentLoginResponse } from './silentLogin.js';
+import { OidcConfiguration } from './types.js';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const startCheckSessionAsync = (oidc:any, oidcDatabase:any, configuration :OidcConfiguration) => (checkSessionIFrameUri, clientId, sessionState, isSilentSignin = false) => {

--- a/packages/react/src/oidc/vanilla/index.ts
+++ b/packages/react/src/oidc/vanilla/index.ts
@@ -1,2 +1,2 @@
-export { AuthorityConfiguration, OidcConfiguration, StringMap } from './types';
-export { VanillaOidc } from './vanillaOidc';
+export { AuthorityConfiguration, OidcConfiguration, StringMap } from './types.js';
+export { VanillaOidc } from './vanillaOidc.js';

--- a/packages/react/src/oidc/vanilla/initWorker.ts
+++ b/packages/react/src/oidc/vanilla/initWorker.ts
@@ -1,6 +1,6 @@
-import { parseOriginalTokens } from './parseTokens';
-import timer from './timer';
-import { OidcConfiguration } from './types';
+import { parseOriginalTokens } from './parseTokens.js';
+import timer from './timer.js';
+import { OidcConfiguration } from './types.js';
 
 export const getOperatingSystem = (navigator) => {
     const nVer = navigator.appVersion;

--- a/packages/react/src/oidc/vanilla/login.ts
+++ b/packages/react/src/oidc/vanilla/login.ts
@@ -1,11 +1,11 @@
-import { generateRandom } from './crypto';
-import { eventNames } from './events';
-import { initSession } from './initSession';
-import { initWorkerAsync } from './initWorker';
-import { isTokensOidcValid } from './parseTokens';
-import { performAuthorizationRequestAsync, performFirstTokenRequestAsync } from './requests';
-import { getParseQueryStringFromLocation } from './route-utils';
-import { OidcConfiguration, StringMap } from './types';
+import { generateRandom } from './crypto.js';
+import { eventNames } from './events.js';
+import { initSession } from './initSession.js';
+import { initWorkerAsync } from './initWorker.js';
+import { isTokensOidcValid } from './parseTokens.js';
+import { performAuthorizationRequestAsync, performFirstTokenRequestAsync } from './requests.js';
+import { getParseQueryStringFromLocation } from './route-utils.js';
+import { OidcConfiguration, StringMap } from './types.js';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const defaultLoginAsync = (window, configurationName, configuration:OidcConfiguration, publishEvent :(string, any)=>void, initAsync:Function) => (callbackPath:string = undefined, extras:StringMap = null, isSilentSignin = false, scope:string = undefined) => {

--- a/packages/react/src/oidc/vanilla/logout.ts
+++ b/packages/react/src/oidc/vanilla/logout.ts
@@ -1,8 +1,8 @@
-import { initSession } from './initSession';
-import { initWorkerAsync } from './initWorker';
-import { performRevocationRequestAsync, TOKEN_TYPE } from './requests';
-import timer from './timer';
-import { StringMap } from './types';
+import { initSession } from './initSession.js';
+import { initWorkerAsync } from './initWorker.js';
+import { performRevocationRequestAsync, TOKEN_TYPE } from './requests.js';
+import timer from './timer.js';
+import { StringMap } from './types.js';
 
 export const destroyAsync = (oidc) => async (status) => {
     timer.clearTimeout(oidc.timeoutId);

--- a/packages/react/src/oidc/vanilla/oidc.ts
+++ b/packages/react/src/oidc/vanilla/oidc.ts
@@ -1,24 +1,24 @@
 
-import { startCheckSessionAsync as defaultStartCheckSessionAsync } from './checkSession';
-import { CheckSessionIFrame } from './checkSessionIFrame';
-import { eventNames } from './events';
-import { initSession } from './initSession';
-import { initWorkerAsync, sleepAsync } from './initWorker';
-import { defaultLoginAsync, loginCallbackAsync } from './login';
-import { destroyAsync, logoutAsync } from './logout';
+import { startCheckSessionAsync as defaultStartCheckSessionAsync } from './checkSession.js';
+import { CheckSessionIFrame } from './checkSessionIFrame.js';
+import { eventNames } from './events.js';
+import { initSession } from './initSession.js';
+import { initWorkerAsync, sleepAsync } from './initWorker.js';
+import { defaultLoginAsync, loginCallbackAsync } from './login.js';
+import { destroyAsync, logoutAsync } from './logout.js';
 import {
     computeTimeLeft,
     isTokensOidcValid,
     setTokens, TokenRenewMode,
     Tokens,
-} from './parseTokens';
-import { autoRenewTokens, renewTokensAndStartTimerAsync } from './renewTokens';
-import { fetchFromIssuer, performTokenRequestAsync } from './requests';
-import { getParseQueryStringFromLocation } from './route-utils';
-import defaultSilentLoginAsync, { _silentLoginAsync } from './silentLogin';
-import timer from './timer';
-import { AuthorityConfiguration, OidcConfiguration, StringMap } from './types';
-import { userInfoAsync } from './user';
+} from './parseTokens.js';
+import { autoRenewTokens, renewTokensAndStartTimerAsync } from './renewTokens.js';
+import { fetchFromIssuer, performTokenRequestAsync } from './requests.js';
+import { getParseQueryStringFromLocation } from './route-utils.js';
+import defaultSilentLoginAsync, { _silentLoginAsync } from './silentLogin.js';
+import timer from './timer.js';
+import { AuthorityConfiguration, OidcConfiguration, StringMap } from './types.js';
+import { userInfoAsync } from './user.js';
 
 export interface OidcAuthorizationServiceConfigurationJson {
     check_session_iframe?: string;

--- a/packages/react/src/oidc/vanilla/parseTokens.ts
+++ b/packages/react/src/oidc/vanilla/parseTokens.ts
@@ -1,4 +1,4 @@
-import { sleepAsync } from './initWorker';
+import { sleepAsync } from './initWorker.js';
 
 const b64DecodeUnicode = (str) =>
     decodeURIComponent(Array.prototype.map.call(atob(str), (c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join(''));

--- a/packages/react/src/oidc/vanilla/renewTokens.ts
+++ b/packages/react/src/oidc/vanilla/renewTokens.ts
@@ -1,9 +1,9 @@
-import { initSession } from './initSession';
-import { initWorkerAsync } from './initWorker';
-import Oidc from './oidc';
-import { computeTimeLeft } from './parseTokens';
-import timer from './timer';
-import { StringMap } from './types';
+import { initSession } from './initSession.js';
+import { initWorkerAsync } from './initWorker.js';
+import Oidc from './oidc.js';
+import { computeTimeLeft } from './parseTokens.js';
+import timer from './timer.js';
+import { StringMap } from './types.js';
 
 export async function renewTokensAndStartTimerAsync(oidc, refreshToken, forceRefresh = false, extras:StringMap = null) {
     const updateTokens = (tokens) => { oidc.tokens = tokens; };

--- a/packages/react/src/oidc/vanilla/requests.ts
+++ b/packages/react/src/oidc/vanilla/requests.ts
@@ -1,8 +1,8 @@
-import { getFromCache, setCache } from './cache';
-import { deriveChallengeAsync, generateRandom } from './crypto';
-import { OidcAuthorizationServiceConfiguration } from './oidc';
-import { parseOriginalTokens } from './parseTokens';
-import { StringMap } from './types';
+import { getFromCache, setCache } from './cache.js';
+import { deriveChallengeAsync, generateRandom } from './crypto.js';
+import { OidcAuthorizationServiceConfiguration } from './oidc.js';
+import { parseOriginalTokens } from './parseTokens.js';
+import { StringMap } from './types.js';
 
 const oneHourSecond = 60 * 60;
 export const fetchFromIssuer = async (openIdIssuerUrl: string, timeCacheSecond = oneHourSecond, storage = window.sessionStorage):

--- a/packages/react/src/oidc/vanilla/silentLogin.ts
+++ b/packages/react/src/oidc/vanilla/silentLogin.ts
@@ -1,8 +1,8 @@
-import { eventNames } from './events';
-import { Tokens } from './parseTokens';
-import { autoRenewTokens } from './renewTokens';
-import timer from './timer';
-import { OidcConfiguration, StringMap } from './types';
+import { eventNames } from './events.js';
+import { Tokens } from './parseTokens.js';
+import { autoRenewTokens } from './renewTokens.js';
+import timer from './timer.js';
+import { OidcConfiguration, StringMap } from './types.js';
 export type SilentLoginResponse = {
     tokens:Tokens;
     sessionState:string;

--- a/packages/react/src/oidc/vanilla/user.ts
+++ b/packages/react/src/oidc/vanilla/user.ts
@@ -1,5 +1,5 @@
-import { sleepAsync } from './initWorker';
-import { isTokensValid } from './parseTokens';
+import { sleepAsync } from './initWorker.js';
+import { isTokensValid } from './parseTokens.js';
 
 export const userInfoAsync = async (oidc) => {
     if (oidc.userInfo != null) {

--- a/packages/react/src/oidc/vanilla/vanillaOidc.ts
+++ b/packages/react/src/oidc/vanilla/vanillaOidc.ts
@@ -1,6 +1,6 @@
-import { LoginCallback, Oidc } from './oidc';
-import { getValidTokenAsync, Tokens, ValidToken } from './parseTokens';
-import { OidcConfiguration, StringMap } from './types';
+import { LoginCallback, Oidc } from './oidc.js';
+import { getValidTokenAsync, Tokens, ValidToken } from './parseTokens.js';
+import { OidcConfiguration, StringMap } from './types.js';
 
 export interface EventSubscriber {
     (name: string, data:any);

--- a/packages/react/src/override/AuthenticateError.component.tsx
+++ b/packages/react/src/override/AuthenticateError.component.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ComponentType } from 'react';
 
-import { style } from './style';
+import { style } from './style.js';
 
 const AuthenticatingError: ComponentType<any> = ({ configurationName }) => (
      <div className="oidc-authenticating" style={style}>

--- a/packages/react/src/override/Callback.component.tsx
+++ b/packages/react/src/override/Callback.component.tsx
@@ -1,6 +1,6 @@
 import { ComponentType } from 'react';
 
-import { style } from './style';
+import { style } from './style.js';
 
 export const CallBackSuccess: ComponentType<any> = ({ configurationName }) => (<><div className="oidc-callback" style={style}>
   <div className="oidc-callback__container">

--- a/packages/react/src/override/Loading.component.tsx
+++ b/packages/react/src/override/Loading.component.tsx
@@ -1,6 +1,6 @@
 import { ComponentType } from 'react';
 
-import { style } from './style';
+import { style } from './style.js';
 
 const Loading : ComponentType<any> = ({ configurationName }) => (
       <span className="oidc-loading" style={style}>

--- a/packages/react/src/override/ServiceWorkerNotSupported.component.tsx
+++ b/packages/react/src/override/ServiceWorkerNotSupported.component.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ComponentType } from 'react';
 
-import { style } from './style';
+import { style } from './style.js';
 
 const ServiceWorkerNotSupported : ComponentType<any> = ({ configurationName }) => (
   <div className="oidc-serviceworker" style={style}>

--- a/packages/react/src/override/SessionLost.component.tsx
+++ b/packages/react/src/override/SessionLost.component.tsx
@@ -1,7 +1,7 @@
 import { ComponentType } from 'react';
 
-import { useOidc } from '../oidc';
-import { style } from './style';
+import { useOidc } from '../oidc.js';
+import { style } from './style.js';
 
 export const SessionLost: ComponentType<any> = ({ configurationName }) => {
     const { login } = useOidc(configurationName);


### PR DESCRIPTION
## Issue
When `module: ESNext` was introduced in 26c150be3222541bb8e3071c339843137ed9a845 it has broken imports for consumers.

Causing issues described in #1006 

## Resolution
If I understand correctly  https://github.com/microsoft/TypeScript/issues/42151  imports for esmodules should be written with a `.js` extension (there is also a recommendation to set this as the default in vscode etc) , as tsc (by design ?) will not alter import statements in .ts files even when tsconfig is `module: esnext`, 

This PR updates all the imports to have the .js extension.

## Alternatives

- https://github.com/Zoltu/typescript-transformer-append-js-extension

