### PR TITLE
fix(ci): skip task with secrets from for PullRequest

### DIFF
--- a/.github/workflows/azure-static-web-apps-icy-glacier-004ab4303.yml
+++ b/.github/workflows/azure-static-web-apps-icy-glacier-004ab4303.yml
@@ -10,8 +10,15 @@ on:
       - master
 
 jobs:
+  skip_ci:
+    runs-on: ubuntu-latest
+    outputs:
+      canSkip: ${{ steps.check.outputs.canSkip }}
+    steps:
+      - id: check
+        uses: Legorooj/skip-ci@main
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')) && !github.event.pull_request.head.repo.fork && needs.skip_ci.outputs.canSkip != 'true'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
@@ -39,7 +46,7 @@ jobs:
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    if: (github.event_name == 'pull_request' && github.event.action == 'closed') && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,10 +17,39 @@ jobs:
     steps:
       - id: check
         uses: Legorooj/skip-ci@main
+  tests:
+    runs-on: ubuntu-latest
+    if: needs.skip_ci.outputs.canSkip != 'true' && github.event.pull_request.head.repo.fork
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: npm ci
+        run: npm ci
+        working-directory: ./packages/react
+
+      - name: npm prepare
+        run: npm run prepare
+        working-directory: ./packages/react
+
+      - name: npm test
+        run: npm test -- --runInBand --coverage --watchAll=false
+        working-directory: ./packages/react
+
+      - name: npm ci
+        run: npm ci
+        working-directory: ./packages/vanilla
+
+      - name: npm prepare
+        run: npm run prepare
+        working-directory: ./packages/vanilla
+
   build:
     environment: react-oidc
     runs-on: ubuntu-latest
-    if: ${{ needs.skip_ci.outputs.canSkip != 'true' }}
+    if: needs.skip_ci.outputs.canSkip != 'true' && !github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
hi @jafin , this is not perfect but it should allow to run unit test from fork pullrequest.

We may set up a working branch in order to autodeploy demo and alpha-beta after a merge.