### PR TITLE
fix(oidc): wait for valid tokens before capturing value of accessToken

### DIFF
--- a/packages/react/src/oidc/vanilla/user.ts
+++ b/packages/react/src/oidc/vanilla/user.ts
@@ -5,17 +5,18 @@ export const userInfoAsync = async (oidc) => {
     if (oidc.userInfo != null) {
         return oidc.userInfo;
     }
+
+    // We wait the synchronisation before making a request
+    while (oidc.tokens && !isTokensValid(oidc.tokens)) {
+        await sleepAsync(200);
+    }
+
     if (!oidc.tokens) {
         return null;
     }
     const accessToken = oidc.tokens.accessToken;
     if (!accessToken) {
         return null;
-    }
-
-    // We wait the synchronisation before making a request
-    while (oidc.tokens && !isTokensValid(oidc.tokens)) {
-        await sleepAsync(200);
     }
 
     const oidcServerConfiguration = await oidc.initAsync(oidc.configuration.authority, oidc.configuration.authority_configuration);


### PR DESCRIPTION
## A picture tells a thousand words

## Before this PR

Scenario: you have logged into an app and close it to open it again later/the next day. The time you open it again, the idToken/accessToken have been expired, but the refreshToken is still valid. New tokens are generated with the refresh token, but when trying to get the userInfo at the same time, the old accessToken is used.

This happens, because the (possibly invalid) value of `oidc.tokens.accessToken` has been captured in the variable `accessToken`, afterwards it is checked whether the tokens are valid, but in the end the captured value of access token is used to make the userInfo request.

## After this PR

The newly retrieved accessToken is used for the userInfo request.