### PR TITLE
Resolve issue #1016 by updating Vite service worker config

### DIFF
--- a/packages/react/vite.serviceWorker.config.js
+++ b/packages/react/vite.serviceWorker.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
       // Could also be a dictionary or array of multiple entry points
       entry: resolve(__dirname, './service_worker/OidcServiceWorker.ts'),
       name: 'OidcServiceWorker',
-      formats: ['es'],
+      formats: ['cjs'],
       // the proper extensions will be added
       fileName: 'OidcServiceWorker',
     },


### PR DESCRIPTION
Resolve issue #1016 by updating Vite service worker config to output CommonJS instead of ES.

## Before this PR

Since the migration of the `OidcServiceWorker.js` code to TypeScript, there is no `OidcServiceWorker.js` file being generated, instead we have an ES module called `OidcServiceWorker.mjs` instead. This means the `copy.cjs` script silently fails to copy the script over to the `public` folder because of this code:

```
const serviceworkerFilePath = path.join(__dirname, "..", "dist/service_worker", serviceworkerFilename);
if (fs.existsSync(serviceworkerFilePath)) {
...
```

## After this PR

We get a `OidcServiceWorker.js` in the `dist` folder and the `copy.cjs` script should work as before.
