### PR TITLE
Fix issue #1029 by moving minimum sleep duration to query string

### DIFF
--- a/packages/react/service_worker/OidcServiceWorker.ts
+++ b/packages/react/service_worker/OidcServiceWorker.ts
@@ -72,8 +72,8 @@ const keepAliveAsync = async (event: FetchEvent) => {
   const init = { status: 200, statusText: 'oidc-service-worker' };
   const response = new Response('{}', init);
   if (!isFromVanilla) {
-    const originalRequestBody = await originalRequest.json();
-    const minSleepSeconds = originalRequestBody.minSleepSeconds ?? 240;
+    const originalRequestUrl = new URL(originalRequest.url);
+    const minSleepSeconds = Number(originalRequestUrl.searchParams.get('minSleepSeconds')) || 240;
     for (let i = 0; i < minSleepSeconds; i++) {
       await sleep(1000 + Math.floor(Math.random() * 1000));
       const cache = await caches.open('oidc_dummy_cache');

--- a/packages/react/src/oidc/vanilla/initWorker.ts
+++ b/packages/react/src/oidc/vanilla/initWorker.ts
@@ -111,10 +111,9 @@ const keepAlive = () => {
     try {
         const operatingSystem = getOperatingSystem(navigator);
         const minSleepSeconds = operatingSystem.os === 'Android' ? 240 : 150;
-        const promise = fetch('/OidcKeepAliveServiceWorker.json',
-            { body: JSON.stringify({ minSleepSeconds }) });
+        const promise = fetch(`/OidcKeepAliveServiceWorker.json?minSleepSeconds=${minSleepSeconds}`);
         promise.catch(error => { console.log(error); });
-        sleepAsync((minSleepSeconds - 10) * 1000).then(keepAlive);
+        sleepAsync(minSleepSeconds * 1000).then(keepAlive);
     } catch (error) { console.log(error); }
 };
 


### PR DESCRIPTION
## A picture tells a thousand words

As mentioned in issue #1029, `OidcKeepAliveServiceWorker.json` requests were failing because of the `GET` fetch requests not being allowed to contain a body. 

## Before this PR

SW throws exception `TypeError: Failed to execute 'fetch' on 'Window': Request with GET/HEAD method cannot have body.` for keep alive requests.

## After this PR

Keep alive requests succeed properly.