### PR TITLE
fix(oidc): ServiceWorker Correct handling of requests with mode "navigate"

### DIFF
--- a/packages/react/service_worker/OidcServiceWorker.ts
+++ b/packages/react/service_worker/OidcServiceWorker.ts
@@ -108,18 +108,29 @@ const handleFetch = async (event: FetchEvent) => {
     ) {
       await sleep(200);
     }
-    const newRequest = new Request(originalRequest, {
-      headers: {
-        ...serializeHeaders(originalRequest.headers),
-        authorization:
-          'Bearer ' + currentDatabaseForRequestAccessToken.tokens.access_token,
-      },
-      mode: (
-        currentDatabaseForRequestAccessToken.oidcConfiguration as OidcConfiguration
-      ).service_worker_convert_all_requests_to_cors
-        ? 'cors'
-        : originalRequest.mode,
-    });
+    const newRequest =
+      originalRequest.mode == 'navigate'
+        ? new Request(originalRequest, {
+            headers: {
+              ...serializeHeaders(originalRequest.headers),
+              authorization:
+                'Bearer ' +
+                currentDatabaseForRequestAccessToken.tokens.access_token,
+            },
+          })
+        : new Request(originalRequest, {
+            headers: {
+              ...serializeHeaders(originalRequest.headers),
+              authorization:
+                'Bearer ' +
+                currentDatabaseForRequestAccessToken.tokens.access_token,
+            },
+            mode: (
+              currentDatabaseForRequestAccessToken.oidcConfiguration as OidcConfiguration
+            ).service_worker_convert_all_requests_to_cors
+              ? 'cors'
+              : originalRequest.mode,
+          });
 
     //@ts-ignore -- TODO: review, waitUntil takes a promise, this returns a void
     event.waitUntil(event.respondWith(fetch(newRequest)));


### PR DESCRIPTION
## The whole story

Imagine you have mapped your API in a subpath of your application:

- Your App: https://my-domain/
- Your API: https://my-domain/my-api/

The library can handle it well so far. The application makes an ajax request to the API and the ServiceWorker intercepts it and inserts the correct headers.

In a scenario in which the tokens are managed in cookies, you can also call the API endpoints directly in your browser after authentication. E.g. with https://my-domain/my-api/endpoint-with-get-request

The browser would send automatically the cookie and everything would be fine.

This doesn't seem to work with this library and I was wondering why.

I found that where the original request is exchanged and the headers with the tokens are inserted is the trouble spot:

```js
    const newRequest = new Request(originalRequest, {
      headers: {
        ...serializeHeaders(originalRequest.headers),
        authorization:
          'Bearer ' + currentDatabaseForRequestAccessToken.tokens.access_token,
      },
      mode: (
        currentDatabaseForRequestAccessToken.oidcConfiguration as OidcConfiguration
      ).service_worker_convert_all_requests_to_cors
        ? 'cors'
        : originalRequest.mode,
    });
```

The library constructs a new Request creating a copy of `originalRequest`. Furthermore the library try to set the parameter `mode`. 

But if the request is initiated from a browser, then the original request has mode `navigate`. In this case it is not allowed to set the mode afterwards. This is automatically set by the browser from `navigate` to `same-origin`.

See: <https://developer.mozilla.org/en-US/docs/Web/API/Request/Request>

As a result, the command above quietly and secretly uses up.

So my solution, admittedly somewhat simple, is to query the "mode" and generate the request either with the "mode" parameter set or without.

```js
    const newRequest =
      originalRequest.mode == 'navigate'
        ? new Request(originalRequest, {
            headers: {
              ...serializeHeaders(originalRequest.headers),
              authorization:
                'Bearer ' +
                currentDatabaseForRequestAccessToken.tokens.access_token,
            },
          })
        : new Request(originalRequest, {
            headers: {
              ...serializeHeaders(originalRequest.headers),
              authorization:
                'Bearer ' +
                currentDatabaseForRequestAccessToken.tokens.access_token,
            },
            mode: (
              currentDatabaseForRequestAccessToken.oidcConfiguration as OidcConfiguration
            ).service_worker_convert_all_requests_to_cors
              ? 'cors'
              : originalRequest.mode,
          });
```