### PR TITLE
Change the openid hardcoded scope to use the configuration scope

### DIFF
--- a/packages/react/src/oidc/vanilla/checkSession.ts
+++ b/packages/react/src/oidc/vanilla/checkSession.ts
@@ -21,7 +21,7 @@ export const startCheckSessionAsync = (oidc:any, oidcDatabase:any, configuration
                 return silentLoginAsync({
                     prompt: 'none',
                     id_token_hint: idToken,
-                    scope: configuration.scope,
+                    scope: configuration.scope || 'openid',
                 }).then((silentSigninResponse) => {
                     const iFrameIdTokenPayload = silentSigninResponse.tokens.idTokenPayload;
                     if (idTokenPayload.sub === iFrameIdTokenPayload.sub) {

--- a/packages/react/src/oidc/vanilla/checkSession.ts
+++ b/packages/react/src/oidc/vanilla/checkSession.ts
@@ -21,7 +21,7 @@ export const startCheckSessionAsync = (oidc:any, oidcDatabase:any, configuration
                 return silentLoginAsync({
                     prompt: 'none',
                     id_token_hint: idToken,
-                    scope: 'openid',
+                    scope: configuration.scope,
                 }).then((silentSigninResponse) => {
                     const iFrameIdTokenPayload = silentSigninResponse.tokens.idTokenPayload;
                     if (idTokenPayload.sub === iFrameIdTokenPayload.sub) {


### PR DESCRIPTION
The scope was hardcoded in the startCheckSessionAsync function to "openid".
This causes an issue where when we retrieve the token, the scope was only for openid.

I changed the hardcoded scope to use the scopes from the configuration (eg.: configuration.scope)