### PR TITLE
fix(vanilla-demo): proper fetch injection

### DIFF
--- a/packages/vanilla-demo/src/index.tsx
+++ b/packages/vanilla-demo/src/index.tsx
@@ -88,7 +88,7 @@ export const configuration = {
 
 const href = window.location.href;
 
-const vanillaOidc = VanillaOidc.getOrCreate(fetch)(configuration);
+const vanillaOidc = VanillaOidc.getOrCreate(() => fetch)(configuration);
 
 console.log(href);
 


### PR DESCRIPTION
`getFetch` is `private getFetch: () => Fetch;`, which means it should be a function that returns `fetch`, not `fetch` itself.

If you try to run `vanilla-demo` using the local `@axa-fr/vanilla-oidc`, it will throw with "fetch is not a function":

```sh
cd packages/react
npm run i
cd ..
cd vanilla
npm run i
npm link
cd ..
cd vanilla-demo
npm run i
npm link @axa-fr/vanilla-oidc
npm run start
```