### PR TITLE
chore(ci): add way to publish alpha, beta, release (alpha)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -60,14 +60,18 @@ jobs:
         run: |
           last_commit_message=$(git log --format=%B -n 1)
           # Check if last comment and with "(alpha)"
+          echo "TUTU"
           if [[ $last_commit_message == *"(alpha)" ]]; then
             echo "tag=alpha" >> $GITHUB_OUTPUT
+            echo "YOUHOUALPHA"
           fi
           if [[ $last_commit_message == *"(beta)" ]]; then
             echo "tag=beta" >> $GITHUB_OUTPUT
+            echo "YOUHOUALPHA1"
           fi
           if [[ $last_commit_message == *"(release)" ]]; then
             echo "tag=release" >> $GITHUB_OUTPUT
+            echo "YOUHOUALPD"
           fi
 
       - name: Bump version and push tag

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,9 +5,9 @@ name: React Oidc CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   skip_ci:
@@ -54,21 +54,54 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GIT_TOKEN }}
-      
+          
+      - name: Determine Alpha, Beta or Release
+        id: which_tag
+        run: |
+          last_commit_message=$(git log --format=%B -n 1)
+          # Check if last comment and with "(alpha)"
+          if [[ $last_commit_message == *"(alpha)" ]]; then
+            echo "tag=alpha" >> $GITHUB_OUTPUT
+          fi
+          if [[ $last_commit_message == *"(beta)" ]]; then
+            echo "tag=beta" >> $GITHUB_OUTPUT
+          fi
+          if [[ $last_commit_message == *"(release)" ]]; then
+            echo "tag=release" >> $GITHUB_OUTPUT
+          fi
+
       - name: Bump version and push tag
-        id: tag_version
-        if: github.ref == 'refs/heads/master'
+        id: tag_release
+        if: steps.which_tag.ref == 'refs/heads/main' && steps.which_tag.outputs.tag == 'release'
         uses: mathieudutour/github-tag-action@v6.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN  }}
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN  }}
+          dry_run: true
+      - name: Add tag to output step for main branch
+        id: tag
+        run: |
+          if [ '${{ github.ref }}' = 'refs/heads/main' && steps.which_tag.outputs.tag = 'release' ]; then
+            echo "new_version=${{ steps.tag_version.outputs.new_version }}" >> $GITHUB_OUTPUT
+          fi
+          if [ '${{ github.ref }}' = 'refs/heads/main' && (steps.which_tag.outputs.tag = 'alpha' ]; then
+            echo "new_version=${{ steps.tag_version.outputs.new_version }}-alpha${{ github.run_number }}" >> $GITHUB_OUTPUT
+          fi
+          if [ '${{ github.ref }}' = 'refs/heads/main' && (steps.which_tag.outputs.tag = 'beta' ]; then
+            echo "new_version=${{ steps.tag_version.outputs.new_version }}-beta${{ github.run_number }}" >> $GITHUB_OUTPUT
+          fi
       
       - uses: actions/setup-node@v2
         with:
           node-version: 18
 
-      - name: npm version ${{ steps.tag_version.outputs.new_tag }}
-        if: github.ref == 'refs/heads/master'
-        run: npm version ${{ steps.tag_version.outputs.new_tag }}
+      - name: npm version ${{ steps.tag.outputs.new_version }}
+        if: github.ref == 'refs/heads/main' && (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
+        run: npm version ${{ steps.tag.outputs.new_version }}
         working-directory: ./packages/react
       
       - name: npm ci
@@ -85,13 +118,14 @@ jobs:
         
       - id: publish-react
         uses: JS-DevTools/npm-publish@v1
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main' && (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/react/package.json
           
-      - name: npm version ${{ steps.tag_version.outputs.new_tag }}
-        run: npm version ${{ steps.tag_version.outputs.new_tag }}
+      - name: npm version ${{ steps.tag.outputs.new_version }}
+        if: github.ref == 'refs/heads/main' && (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
+        run: npm version ${{ steps.tag.outputs.new_version }}
         working-directory: ./packages/vanilla
 
       - name: npm ci
@@ -104,7 +138,7 @@ jobs:
 
       - id: publish-vanilla
         uses: JS-DevTools/npm-publish@v1
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main' && (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/vanilla/package.json

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -61,15 +61,15 @@ jobs:
           last_commit_message=$(git log --format=%B -n 1)
           # Check if last comment and with "(alpha)"
           echo "TUTU"
-          if [[ "$last_commit_message" == *"alpha"* ]]; then
+          if [[ "$last_commit_message" == *alpha* ]]; then
             echo "tag=alpha" >> $GITHUB_OUTPUT
             echo "YOUHOUALPHA"
           fi
-          if [[ "$last_commit_message" == *"beta"* ]]; then
+          if [[ "$last_commit_message" == *beta* ]]; then
             echo "tag=beta" >> $GITHUB_OUTPUT
             echo "YOUHOUALPHA1"
           fi
-          if [[ "$last_commit_message" == *"release"* ]]; then
+          if [[ "$last_commit_message" == *release* ]]; then
             echo "tag=release" >> $GITHUB_OUTPUT
             echo "YOUHOUALPD"
           fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -60,7 +60,8 @@ jobs:
       - name: Determine Alpha, Beta or Release
         id: which_tag
         run: |
-          last_commit_message=$(git log -1 --pretty=format:"%B" ${{ github.event.pull_request.head.sha }})
+          last_commit_message=$(curl -s "https://api.github.com/repos/AxaFrance/react-oidc/pulls/{{ github.event.number }}/commits" | jq -r '.[-1].commit.message')
+
           # Check if last comment and with "(alpha)", "(beta)" or "(release)"
           echo "TUTU"
           echo $last_commit_message

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -61,15 +61,15 @@ jobs:
           last_commit_message=$(git log --format=%B -n 1)
           # Check if last comment and with "(alpha)"
           echo "TUTU"
-          if [[ "$last_commit_message" == *"(alpha)" ]]; then
+          if [[ "$last_commit_message" == *(alpha) ]]; then
             echo "tag=alpha" >> $GITHUB_OUTPUT
             echo "YOUHOUALPHA"
           fi
-          if [[ "$last_commit_message" == *"(beta)" ]]; then
+          if [[ "$last_commit_message" == *(beta) ]]; then
             echo "tag=beta" >> $GITHUB_OUTPUT
             echo "YOUHOUALPHA1"
           fi
-          if [[ "$last_commit_message" == *"(release)" ]]; then
+          if [[ "$last_commit_message" == *(release) ]]; then
             echo "tag=release" >> $GITHUB_OUTPUT
             echo "YOUHOUALPD"
           fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -65,13 +65,13 @@ jobs:
           fi
           echo "last commit message is: $last_commit_message"
           # Check if last comment and with "(alpha)", "(beta)" or "(release)"
-          if [[ $last_commit_message == *(alpha) ]]; then
+          if [[ $last_commit_message == *(alpha)* ]]; then
             echo "tag=alpha" >> $GITHUB_OUTPUT
           fi
-          if [[ $last_commit_message == *(beta) ]]; then
+          if [[ $last_commit_message == *(beta)* ]]; then
             echo "tag=beta" >> $GITHUB_OUTPUT
           fi
-          if [[ $last_commit_message == *(release) ]]; then
+          if [[ $last_commit_message == *(release)* ]]; then
             echo "tag=release" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Determine Alpha, Beta or Release
         id: which_tag
         run: |
-          last_commit_message=${{github.event.commits[0].message}}
+          last_commit_message="${{ github.event.head_commit.message }}"
           # Check if last comment and with "(alpha)"
           echo "TUTU"
           echo $last_commit_message

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -61,15 +61,16 @@ jobs:
           last_commit_message=$(git log --format=%B -n 1)
           # Check if last comment and with "(alpha)"
           echo "TUTU"
-          if [[ "$last_commit_message" == *alpha* ]]; then
+          echo $last_commit_message
+          if [[ $last_commit_message == *alpha* ]]; then
             echo "tag=alpha" >> $GITHUB_OUTPUT
             echo "YOUHOUALPHA"
           fi
-          if [[ "$last_commit_message" == *beta* ]]; then
+          if [[ $last_commit_message == *beta* ]]; then
             echo "tag=beta" >> $GITHUB_OUTPUT
             echo "YOUHOUALPHA1"
           fi
-          if [[ "$last_commit_message" == *release* ]]; then
+          if [[ $last_commit_message == *release* ]]; then
             echo "tag=release" >> $GITHUB_OUTPUT
             echo "YOUHOUALPD"
           fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -61,7 +61,7 @@ jobs:
           commit_message: ${{ github.event.head_commit.message }}
         run: |
           last_commit_message="$commit_message"
-          # Check if last comment and with "(alpha)"
+          # Check if last comment and with "(alpha)", "(beta)" or "(release)"
           echo "TUTU"
           echo $last_commit_message
           if [[ $last_commit_message == *alpha* ]]; then

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Determine Alpha, Beta or Release
         id: which_tag
         run: |
-          last_commit_message=" ${{ env.commit_message }}"
+          last_commit_message=$(git log -1 --pretty=format:"%B" ${{ github.event.pull_request.head.sha }})
           # Check if last comment and with "(alpha)", "(beta)" or "(release)"
           echo "TUTU"
           echo $last_commit_message

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -47,7 +47,7 @@ jobs:
         working-directory: ./packages/vanilla
 
   build:
-    environment: react-oidc
+   # environment: react-oidc
     runs-on: ubuntu-latest
     if: needs.skip_ci.outputs.canSkip != 'true' && !github.event.pull_request.head.repo.fork
     env:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -59,26 +59,21 @@ jobs:
         id: which_tag
         run: |
           last_commit_message=$(curl -s "https://api.github.com/repos/AxaFrance/react-oidc/pulls/${{ github.event.number }}/commits" | jq -r '.[-1].commit.message')
-          #last_commit_message="${{ github.event.head_commit.message }}"
           # Check if last comment and with "(alpha)", "(beta)" or "(release)"
-          echo "TUTU"
           echo $last_commit_message
           if [[ $last_commit_message == *alpha* ]]; then
             echo "tag=alpha" >> $GITHUB_OUTPUT
-            echo "YOUHOUALPHA"
           fi
           if [[ $last_commit_message == *beta* ]]; then
             echo "tag=beta" >> $GITHUB_OUTPUT
-            echo "YOUHOUALPHA1"
           fi
           if [[ $last_commit_message == *release* ]]; then
             echo "tag=release" >> $GITHUB_OUTPUT
-            echo "YOUHOUALPD"
           fi
 
       - name: Bump version and push tag
         id: tag_release
-        #if: steps.which_tag.ref == 'refs/heads/main' && steps.which_tag.outputs.tag == 'release'
+        if: steps.which_tag.ref == 'refs/heads/main' && steps.which_tag.outputs.tag == 'release'
         uses: mathieudutour/github-tag-action@v6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN  }}
@@ -93,15 +88,12 @@ jobs:
         run: |
           if [[ '${{ steps.which_tag.outputs.tag }}' = 'release' ]]; then
             echo "new_version=${{ steps.tag_version.outputs.new_version }}" >> $GITHUB_OUTPUT
-            echo "ssss"
           fi
           if [[ '${{ steps.which_tag.outputs.tag }}' = 'alpha' ]]; then
             echo "new_version=${{ steps.tag_version.outputs.new_version }}-alpha${{ github.run_number }}" >> $GITHUB_OUTPUT
-            echo "saaaaaa"
           fi
           if [[ '${{ steps.which_tag.outputs.tag }}' = 'beta' ]]; then
             echo "new_version=${{ steps.tag_version.outputs.new_version }}-beta${{ github.run_number }}" >> $GITHUB_OUTPUT
-            echo "eeee"
           fi
       
       - uses: actions/setup-node@v2
@@ -109,7 +101,7 @@ jobs:
           node-version: 18
 
       - name: npm version ${{ steps.tag.outputs.new_version }}
-        if: (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
+        if: steps.which_tag.ref == 'refs/heads/main' && (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
         run: npm version ${{ steps.tag.outputs.new_version }}
         working-directory: ./packages/react
       
@@ -127,13 +119,13 @@ jobs:
         
       - id: publish-react
         uses: JS-DevTools/npm-publish@v1
-        if: (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
+        if: steps.which_tag.ref == 'refs/heads/main' && (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/react/package.json
           
       - name: npm version ${{ steps.tag.outputs.new_version }}
-        if: (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
+        if: steps.which_tag.ref == 'refs/heads/main' && (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
         run: npm version ${{ steps.tag.outputs.new_version }}
         working-directory: ./packages/vanilla
 
@@ -147,7 +139,7 @@ jobs:
 
       - id: publish-vanilla
         uses: JS-DevTools/npm-publish@v1
-        if: (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
+        if: steps.which_tag.ref == 'refs/heads/main' && (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/vanilla/package.json

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -47,7 +47,7 @@ jobs:
         working-directory: ./packages/vanilla
 
   build:
-   # environment: react-oidc
+    environment: react-oidc
     runs-on: ubuntu-latest
     if: needs.skip_ci.outputs.canSkip != 'true' && !github.event.pull_request.head.repo.fork
     env:
@@ -60,7 +60,7 @@ jobs:
       - name: Determine Alpha, Beta or Release
         id: which_tag
         run: |
-          last_commit_message=$(curl -s "https://api.github.com/repos/AxaFrance/react-oidc/pulls/{{ github.event.number }}/commits" | jq -r '.[-1].commit.message')
+          last_commit_message=$(curl -s "https://api.github.com/repos/AxaFrance/react-oidc/pulls/${{ github.event.number }}/commits" | jq -r '.[-1].commit.message')
 
           # Check if last comment and with "(alpha)", "(beta)" or "(release)"
           echo "TUTU"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -58,16 +58,20 @@ jobs:
       - name: Determine Alpha, Beta or Release
         id: which_tag
         run: |
-          last_commit_message=$(curl -s "https://api.github.com/repos/AxaFrance/react-oidc/pulls/${{ github.event.number }}/commits" | jq -r '.[-1].commit.message')
+          if [[ ${{ github.ref }} == refs/pull* ]]; then
+            last_commit_message=$(curl -s "https://api.github.com/repos/AxaFrance/react-oidc/pulls/${{ github.event.number }}/commits" | jq -r '.[-1].commit.message')
+          else
+            last_commit_message=$(git log --format=%B -n 1)
+          fi
+          echo "last commit message is: $last_commit_message"
           # Check if last comment and with "(alpha)", "(beta)" or "(release)"
-          echo $last_commit_message
-          if [[ $last_commit_message == *alpha* ]]; then
+          if [[ $last_commit_message == *(alpha) ]]; then
             echo "tag=alpha" >> $GITHUB_OUTPUT
           fi
-          if [[ $last_commit_message == *beta* ]]; then
+          if [[ $last_commit_message == *(beta) ]]; then
             echo "tag=beta" >> $GITHUB_OUTPUT
           fi
-          if [[ $last_commit_message == *release* ]]; then
+          if [[ $last_commit_message == *(release) ]]; then
             echo "tag=release" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -50,6 +50,8 @@ jobs:
     environment: react-oidc
     runs-on: ubuntu-latest
     if: needs.skip_ci.outputs.canSkip != 'true' && !github.event.pull_request.head.repo.fork
+    env:
+      commit_message: ${{ github.event.head_commit.message }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -57,10 +59,8 @@ jobs:
           
       - name: Determine Alpha, Beta or Release
         id: which_tag
-        env:
-          commit_message: ${{ github.event.head_commit.message }}
         run: |
-          last_commit_message="$commit_message"
+          last_commit_message=" ${{ env.commit_message }}"
           # Check if last comment and with "(alpha)", "(beta)" or "(release)"
           echo "TUTU"
           echo $last_commit_message

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -50,8 +50,6 @@ jobs:
     environment: react-oidc
     runs-on: ubuntu-latest
     if: needs.skip_ci.outputs.canSkip != 'true' && !github.event.pull_request.head.repo.fork
-    env:
-      commit_message: ${{ github.event.head_commit.message }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -60,8 +58,8 @@ jobs:
       - name: Determine Alpha, Beta or Release
         id: which_tag
         run: |
-          last_commit_message=$(curl -s "https://api.github.com/repos/AxaFrance/react-oidc/pulls/${{ github.event.number }}/commits" | jq -r '.[-1].commit.message')
-
+          #last_commit_message=$(curl -s "https://api.github.com/repos/AxaFrance/react-oidc/pulls/${{ github.event.number }}/commits" | jq -r '.[-1].commit.message')
+          last_commit_message="${{ github.event.head_commit.message }}"
           # Check if last comment and with "(alpha)", "(beta)" or "(release)"
           echo "TUTU"
           echo $last_commit_message
@@ -93,13 +91,13 @@ jobs:
       - name: Add tag to output step for main branch
         id: tag
         run: |
-          if [[ '${{ github.ref }}' = 'refs/heads/main' && steps.which_tag.outputs.tag = 'release' ]]; then
+          if [[ '${{ github.ref }}' != 'refs/heads/main' && steps.which_tag.outputs.tag = 'release' ]]; then
             echo "new_version=${{ steps.tag_version.outputs.new_version }}" >> $GITHUB_OUTPUT
           fi
-          if [[ '${{ github.ref }}' = 'refs/heads/main' && steps.which_tag.outputs.tag = 'alpha' ]]; then
+          if [[ '${{ github.ref }}' != 'refs/heads/main' && steps.which_tag.outputs.tag = 'alpha' ]]; then
             echo "new_version=${{ steps.tag_version.outputs.new_version }}-alpha${{ github.run_number }}" >> $GITHUB_OUTPUT
           fi
-          if [[ '${{ github.ref }}' = 'refs/heads/main' && steps.which_tag.outputs.tag = 'beta' ]]; then
+          if [[ '${{ github.ref }}' != 'refs/heads/main' && steps.which_tag.outputs.tag = 'beta' ]]; then
             echo "new_version=${{ steps.tag_version.outputs.new_version }}-beta${{ github.run_number }}" >> $GITHUB_OUTPUT
           fi
       

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -61,15 +61,15 @@ jobs:
           last_commit_message=$(git log --format=%B -n 1)
           # Check if last comment and with "(alpha)"
           echo "TUTU"
-          if [[ "$last_commit_message" == *(alpha) ]]; then
+          if [[ "$last_commit_message" == *"(alpha)" ]]; then
             echo "tag=alpha" >> $GITHUB_OUTPUT
             echo "YOUHOUALPHA"
           fi
-          if [[ "$last_commit_message" == *(beta) ]]; then
+          if [[ "$last_commit_message" == *"(beta)" ]]; then
             echo "tag=beta" >> $GITHUB_OUTPUT
             echo "YOUHOUALPHA1"
           fi
-          if [[ "$last_commit_message" == *(release) ]]; then
+          if [[ "$last_commit_message" == *"(release)" ]]; then
             echo "tag=release" >> $GITHUB_OUTPUT
             echo "YOUHOUALPD"
           fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -79,6 +79,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN  }}
       - name: Bump version and push tag
         id: tag_version
+        if: steps.which_tag.ref == 'refs/heads/main' && (steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
         uses: mathieudutour/github-tag-action@v6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN  }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -85,13 +85,13 @@ jobs:
       - name: Add tag to output step for main branch
         id: tag
         run: |
-          if [ '${{ github.ref }}' = 'refs/heads/main' && steps.which_tag.outputs.tag = 'release' ]; then
+          if [[ '${{ github.ref }}' = 'refs/heads/main' && steps.which_tag.outputs.tag = 'release' ]]; then
             echo "new_version=${{ steps.tag_version.outputs.new_version }}" >> $GITHUB_OUTPUT
           fi
-          if [ '${{ github.ref }}' = 'refs/heads/main' && (steps.which_tag.outputs.tag = 'alpha' ]; then
+          if [[ '${{ github.ref }}' = 'refs/heads/main' && (steps.which_tag.outputs.tag = 'alpha' ]]; then
             echo "new_version=${{ steps.tag_version.outputs.new_version }}-alpha${{ github.run_number }}" >> $GITHUB_OUTPUT
           fi
-          if [ '${{ github.ref }}' = 'refs/heads/main' && (steps.which_tag.outputs.tag = 'beta' ]; then
+          if [[ '${{ github.ref }}' = 'refs/heads/main' && (steps.which_tag.outputs.tag = 'beta' ]]; then
             echo "new_version=${{ steps.tag_version.outputs.new_version }}-beta${{ github.run_number }}" >> $GITHUB_OUTPUT
           fi
       

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Determine Alpha, Beta or Release
         id: which_tag
         run: |
-          #last_commit_message=$(curl -s "https://api.github.com/repos/AxaFrance/react-oidc/pulls/${{ github.event.number }}/commits" | jq -r '.[-1].commit.message')
-          last_commit_message="${{ github.event.head_commit.message }}"
+          last_commit_message=$(curl -s "https://api.github.com/repos/AxaFrance/react-oidc/pulls/${{ github.event.number }}/commits" | jq -r '.[-1].commit.message')
+          #last_commit_message="${{ github.event.head_commit.message }}"
           # Check if last comment and with "(alpha)", "(beta)" or "(release)"
           echo "TUTU"
           echo $last_commit_message

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -91,14 +91,17 @@ jobs:
       - name: Add tag to output step for main branch
         id: tag
         run: |
-          if [[ '${{ github.ref }}' != 'refs/heads/main' && steps.which_tag.outputs.tag = 'release' ]]; then
+          if [[ '${{ steps.which_tag.outputs.tag }}' = 'release' ]]; then
             echo "new_version=${{ steps.tag_version.outputs.new_version }}" >> $GITHUB_OUTPUT
+            echo "ssss"
           fi
-          if [[ '${{ github.ref }}' != 'refs/heads/main' && steps.which_tag.outputs.tag = 'alpha' ]]; then
+          if [[ '${{ steps.which_tag.outputs.tag }}' = 'alpha' ]]; then
             echo "new_version=${{ steps.tag_version.outputs.new_version }}-alpha${{ github.run_number }}" >> $GITHUB_OUTPUT
+            echo "saaaaaa"
           fi
-          if [[ '${{ github.ref }}' != 'refs/heads/main' && steps.which_tag.outputs.tag = 'beta' ]]; then
+          if [[ '${{ steps.which_tag.outputs.tag }}' = 'beta' ]]; then
             echo "new_version=${{ steps.tag_version.outputs.new_version }}-beta${{ github.run_number }}" >> $GITHUB_OUTPUT
+            echo "eeee"
           fi
       
       - uses: actions/setup-node@v2

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -61,15 +61,15 @@ jobs:
           last_commit_message=$(git log --format=%B -n 1)
           # Check if last comment and with "(alpha)"
           echo "TUTU"
-          if [[ "$last_commit_message" == *"(alpha)" ]]; then
+          if [[ "$last_commit_message" == *"alpha"* ]]; then
             echo "tag=alpha" >> $GITHUB_OUTPUT
             echo "YOUHOUALPHA"
           fi
-          if [[ "$last_commit_message" == *"(beta)" ]]; then
+          if [[ "$last_commit_message" == *"beta"* ]]; then
             echo "tag=beta" >> $GITHUB_OUTPUT
             echo "YOUHOUALPHA1"
           fi
-          if [[ "$last_commit_message" == *"(release)" ]]; then
+          if [[ "$last_commit_message" == *"release"* ]]; then
             echo "tag=release" >> $GITHUB_OUTPUT
             echo "YOUHOUALPD"
           fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -88,10 +88,10 @@ jobs:
           if [[ '${{ github.ref }}' = 'refs/heads/main' && steps.which_tag.outputs.tag = 'release' ]]; then
             echo "new_version=${{ steps.tag_version.outputs.new_version }}" >> $GITHUB_OUTPUT
           fi
-          if [[ '${{ github.ref }}' = 'refs/heads/main' && (steps.which_tag.outputs.tag = 'alpha' ]]; then
+          if [[ '${{ github.ref }}' = 'refs/heads/main' && steps.which_tag.outputs.tag = 'alpha' ]]; then
             echo "new_version=${{ steps.tag_version.outputs.new_version }}-alpha${{ github.run_number }}" >> $GITHUB_OUTPUT
           fi
-          if [[ '${{ github.ref }}' = 'refs/heads/main' && (steps.which_tag.outputs.tag = 'beta' ]]; then
+          if [[ '${{ github.ref }}' = 'refs/heads/main' && steps.which_tag.outputs.tag = 'beta' ]]; then
             echo "new_version=${{ steps.tag_version.outputs.new_version }}-beta${{ github.run_number }}" >> $GITHUB_OUTPUT
           fi
       

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Bump version and push tag
         id: tag_release
-        if: steps.which_tag.ref == 'refs/heads/main' && steps.which_tag.outputs.tag == 'release'
+        #if: steps.which_tag.ref == 'refs/heads/main' && steps.which_tag.outputs.tag == 'release'
         uses: mathieudutour/github-tag-action@v6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN  }}
@@ -100,7 +100,7 @@ jobs:
           node-version: 18
 
       - name: npm version ${{ steps.tag.outputs.new_version }}
-        if: github.ref == 'refs/heads/main' && (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
+        if: (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
         run: npm version ${{ steps.tag.outputs.new_version }}
         working-directory: ./packages/react
       
@@ -118,13 +118,13 @@ jobs:
         
       - id: publish-react
         uses: JS-DevTools/npm-publish@v1
-        if: github.ref == 'refs/heads/main' && (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
+        if: (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/react/package.json
           
       - name: npm version ${{ steps.tag.outputs.new_version }}
-        if: github.ref == 'refs/heads/main' && (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
+        if: (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
         run: npm version ${{ steps.tag.outputs.new_version }}
         working-directory: ./packages/vanilla
 
@@ -138,7 +138,7 @@ jobs:
 
       - id: publish-vanilla
         uses: JS-DevTools/npm-publish@v1
-        if: github.ref == 'refs/heads/main' && (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
+        if: (steps.which_tag.outputs.tag == 'release' || steps.which_tag.outputs.tag == 'alpha' || steps.which_tag.outputs.tag == 'beta')
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/vanilla/package.json

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Determine Alpha, Beta or Release
         id: which_tag
         run: |
-          last_commit_message=$(git log --format=%B -n 1)
+          last_commit_message=${{github.event.commits[0].message}}
           # Check if last comment and with "(alpha)"
           echo "TUTU"
           echo $last_commit_message

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -61,15 +61,15 @@ jobs:
           last_commit_message=$(git log --format=%B -n 1)
           # Check if last comment and with "(alpha)"
           echo "TUTU"
-          if [[ $last_commit_message == *"(alpha)" ]]; then
+          if [[ "$last_commit_message" == *"(alpha)" ]]; then
             echo "tag=alpha" >> $GITHUB_OUTPUT
             echo "YOUHOUALPHA"
           fi
-          if [[ $last_commit_message == *"(beta)" ]]; then
+          if [[ "$last_commit_message" == *"(beta)" ]]; then
             echo "tag=beta" >> $GITHUB_OUTPUT
             echo "YOUHOUALPHA1"
           fi
-          if [[ $last_commit_message == *"(release)" ]]; then
+          if [[ "$last_commit_message" == *"(release)" ]]; then
             echo "tag=release" >> $GITHUB_OUTPUT
             echo "YOUHOUALPD"
           fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -57,8 +57,10 @@ jobs:
           
       - name: Determine Alpha, Beta or Release
         id: which_tag
+        env:
+          commit_message: ${{ github.event.head_commit.message }}
         run: |
-          last_commit_message="${{ github.event.head_commit.message }}"
+          last_commit_message="$commit_message"
           # Check if last comment and with "(alpha)"
           echo "TUTU"
           echo $last_commit_message

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,17 +20,17 @@ Packages are automaticaly published on npm when a PR is merged on main.
 
 Example of commit messages :
 
-
+To publish a patch version (0.0.x) :
 - fix(oidc): my message (alpha) => will publish next patch as an alpha
-- fix(oidc): my message (beta) => will publish next patch as an beta
-- fix(oidc): my message (release) => will publish next patch release (with automatic git tag and release)
+- chore(oidc): my message (beta) => will publish next patch as an beta
+- refactor(oidc): my message (release) => will publish next patch release (with automatic git tag and release)
 
-
+To publish a minor version (0.x.0) :
 - feat(oidc): my message (alpha) => will publish next minor as an alpha
 - feat(oidc): my message (beta) => will publish next minor as an beta
 - feat(oidc): my message (release) => will publish next minor release (with automatic git tag and release)
 
-
+To publish a major version (x.0.0) :
 - fix(oidc): my message containing BREACKING word (alpha) => will publish next major as an alpha
 - fix(oidc): my message containing BREACKING word (beta) => will publish next major as an beta
 - fix(oidc): my message containing BREACKING word (release) => will publish next major release (with automatic git tag and release)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,26 @@ You are now ready to contribute!
 
 Please respect the following [PULL_REQUEST_TEMPLATE.md](./PULL_REQUEST_TEMPLATE.md)
 
+Packages are automaticaly published on npm when a PR is merged on main.
+
+Example of commit messages :
+
+
+- fix(oidc): my message (alpha) => will publish next patch as an alpha
+- fix(oidc): my message (beta) => will publish next patch as an beta
+- fix(oidc): my message (release) => will publish next patch release (with automatic git tag and release)
+
+
+- feat(oidc): my message (alpha) => will publish next minor as an alpha
+- feat(oidc): my message (beta) => will publish next minor as an beta
+- feat(oidc): my message (release) => will publish next minor release (with automatic git tag and release)
+
+
+- fix(oidc): my message containing BREACKING word (alpha) => will publish next major as an alpha
+- fix(oidc): my message containing BREACKING word (beta) => will publish next major as an beta
+- fix(oidc): my message containing BREACKING word (release) => will publish next major release (with automatic git tag and release)
+
+
 ## Issue
 
 Please respect the following [ISSUE_TEMPLATE.md](./ISSUE_TEMPLATE.md)


### PR DESCRIPTION
Packages are automaticaly published on npm when a PR is merged on main.

Example of commit messages :

To publish a patch version (0.0.x) :
- fix(oidc): my message (alpha) => will publish next patch as an alpha
- chore(oidc): my message (beta) => will publish next patch as an beta
- refactor(oidc): my message (release) => will publish next patch release (with automatic git tag and release)

To publish a minor version (0.x.0) :
- feat(oidc): my message (alpha) => will publish next minor as an alpha
- feat(oidc): my message (beta) => will publish next minor as an beta
- feat(oidc): my message (release) => will publish next minor release (with automatic git tag and release)

To publish a major version (x.0.0) :
- fix(oidc): my message containing BREACKING word (alpha) => will publish next major as an alpha
- fix(oidc): my message containing BREACKING word (beta) => will publish next major as an beta
- fix(oidc): my message containing BREACKING word (release) => will publish next major release (with automatic git tag and release)

