### PR TITLE
ci(version): Add a period between version alpha|beta and run_number

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -111,10 +111,10 @@ jobs:
             echo "new_version=$version" >> $GITHUB_OUTPUT
           fi
           if [[ '${{ steps.which_tag.outputs.tag }}' = 'alpha' ]]; then
-            echo "new_version=$version-alpha${{ github.run_number }}" >> $GITHUB_OUTPUT
+            echo "new_version=$version-alpha.${{ github.run_number }}" >> $GITHUB_OUTPUT
           fi
           if [[ '${{ steps.which_tag.outputs.tag }}' = 'beta' ]]; then
-            echo "new_version=$version-beta${{ github.run_number }}" >> $GITHUB_OUTPUT
+            echo "new_version=$version-beta.${{ github.run_number }}" >> $GITHUB_OUTPUT
           fi
       
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Introduce a period between the `alpha|version` meta tag and the `build number`.
Although not strictly semver (they appear to use a +) apparently NPM will strip the + metadata though so that is not ideal.
It appears common for libs to use the format  `x.xxx-beta.xx`

This change aligns to that format.

## Before this PR

Version would be `1.4.0-alpha5`

## After this PR

Version will be `1.4.0-alpha.5`
